### PR TITLE
Update to correct installation issue

### DIFF
--- a/resources/install.sh
+++ b/resources/install.sh
@@ -3,7 +3,7 @@
 apt-get -y install lsb-release
 archi=`lscpu | grep Architecture | awk '{ print $2 }'`
 
-if [$archi == "x86_64"]; then
+if ["$archi" == "x86_64"]; then
 if [ `lsb_release -i -s` == "Debian" ]; then
   wget http://repo.mosquitto.org/debian/mosquitto-repo.gpg.key
   apt-key add mosquitto-repo.gpg.key


### PR DESCRIPTION
Missing quotes. Dependencies not installing as the apt repository is not updated due to the error.