### PR TITLE
Fix : prevent non-correct topics

### DIFF
--- a/core/class/MQTT.class.php
+++ b/core/class/MQTT.class.php
@@ -247,8 +247,8 @@ class MQTT extends eqLogic {
     log::add('MQTT', 'debug', 'Message ' . $message->payload . ' sur ' . $message->topic);
     $topic = $message->topic;
 
-    if(!ctype_print($message->topic)) {
-      log::add('MQTT', 'debug', "Message skipped : $message->topic is not a valid topic");
+    if(!ctype_print($message->topic) || empty($message->topic) || $message->topic[0] != '/') {
+      log::add('MQTT', 'debug', 'Message skipped : "'.$message->topic.'" is not a valid topic');
       return;
     }
 


### PR DESCRIPTION
J'ai des éléments qui envoient des topics bidons sur le broker.
La découverte automatique des topics tourne alors en rond jusqu'à saturer les logs :
EN : 
> I've got ESPs that send unwanted (bogus) topics to the broker.
> The "Automatic topic discovering" is going turning in circles till making the log file full.

________________
[2017-04-25 22:44:33][DEBUG] : 16 : Client Jeedom received PUBLISH (d0, q0, r1, m0, '�4/2017', ... (1 bytes))
[2017-04-25 22:44:33][DEBUG] : Message 0 sur �4/2017
[2017-04-25 22:44:33][DEBUG] : Message skipped : �4/2017 is not a valid topic
________________
[2017-04-25 22:44:33][DEBUG] : 16 : Client Jeedom received PUBLISH (d0, q0, r1, m0, 'x	4/2017', ... (1 bytes))
[2017-04-25 22:44:33][DEBUG] : Message 0 sur x	4/2017
[2017-04-25 22:44:33][DEBUG] : Message skipped : x	4/2017 is not a valid topic
________________
[2017-04-25 22:44:33][DEBUG] : 16 : Client Jeedom received PUBLISH (d0, q0, r1, m0, '', ... (1 bytes))
[2017-04-25 22:44:33][DEBUG] : Message 0 sur
[2017-04-25 22:44:33][DEBUG] : Message skipped :  is not a valid topic
________________
[2017-04-25 22:44:33][DEBUG] : 16 : Client Jeedom received PUBLISH (d0, q0, r1, m0, '�', ... (1 bytes))
[2017-04-25 22:44:33][DEBUG] : Message 0 sur �
[2017-04-25 22:44:33][DEBUG] : Message skipped : � is not a valid topic
________________