### PR TITLE
Handle message with too short or incorrect topic

### DIFF
--- a/core/class/MQTT.class.php
+++ b/core/class/MQTT.class.php
@@ -156,6 +156,11 @@ class MQTT extends eqLogic {
       $nodeid = implode($topicArray,'/');
       $value = $message->payload;
       $type = 'topic';
+
+      if ($nodeid == "" || $cmdId == "") {
+        log::add('MQTT', 'info', $message->topic . ' est un topic trop court ou incorrect pour un Message texte');
+        return;
+      }
       log::add('MQTT', 'info', 'Message texte : ' . $value . ' pour information : ' . $cmdId . ' sur : ' . $nodeid);
     }
 


### PR DESCRIPTION
Bonjour,

Petite gestion d'erreur concernant : 
 - les publications MQTT courtes (1 seul niveau et payload non-JSON).
 - les publications MQTT finissant par '/' (payload non-JSON). (Ce second cas étant beaucoup plus rare :-D)

Exemple si on publie sur le topic "jeedomTest" le payload "90" : 

[2021-01-02 23:42:12][DEBUG] : 16 : Client MQTT received PUBLISH (d0, q0, r0, m0, 'jeedomTest', ... (2 bytes))
[2021-01-02 23:42:12][DEBUG] : Message 90 sur jeedomTest
[2021-01-02 23:42:12][INFO] : Message texte : 90 pour information : jeedomTest sur :
[2021-01-02 23:42:12][INFO] : Saving device
[2021-01-02 23:42:12][ERROR] : Le nom de l'équipement ne peut pas être vide : MQTT Object (     [id:protected] =>      [name:protected] =>      [logicalId:protected] =>      [generic_type:protected] =>      [object_id:protected] =>      [eqType_name:protected] => MQTT     [eqReal_id:protected] =>      [isVisible:protected] => 0     [isEnable:protected] => 0     [configuration:protected] => Array         (             [topic] =>              [type] => topic         )      [timeout:protected] => 0     [category:protected] =>      [display:protected] =>      [order:protected] => 9999     [comment:protected] =>      [tags:protected] =>      [_debug:protected] =>      [_object:protected] =>      [_needRefreshWidget:protected] =>      [_timeoutUpdated:protected] =>      [_batteryUpdated:protected] =>      [_changed:protected] => 1 )
[2021-01-02 23:42:12][DEBUG] : 16 : Client MQTT sending DISCONNECT
...
